### PR TITLE
Add 'base' to packages

### DIFF
--- a/commands/activate.js
+++ b/commands/activate.js
@@ -36,7 +36,7 @@ const snipsnapActivate = (workspace, packageUri) => {
           language: 'javascript',
           ide: 'vscode',
           // TODO: think of a way of filtering snippetless packages, e.g. sharp
-          packages: completeDepsList,
+          packages: ['base', ...completeDepsList],
         });
 
         // making an API call


### PR DESCRIPTION
As per plans described above, https://github.com/snipsnapdev/snipsnap/issues/36 added functionality of fetching from the backend also base javascript snippets, such as for loops, try, map, reduce, import, export conditions. 