### PR TITLE
Simple silent mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 ![out](https://user-images.githubusercontent.com/2697570/73568644-23bc0180-4469-11ea-8b64-843c7a9a92d2.gif)
 
-
 <p align="center">
   <a href="https://drone.pixelpoint.io/snipsnapdev/snipsnap-vscode"><img src="https://img.shields.io/drone/build/snipsnapdev/snipsnap-vscode?server=https%3A%2F%2Fdrone.pixelpoint.io" /></a>
   <a href="https://marketplace.visualstudio.com/items?itemName=snipsnapdev.snipsnap-vscode">
@@ -45,6 +44,7 @@
 ## How to search for a snippet?
 
 **Search library's snippets**
+
 - Type your library name, if it's present in the [list](https://github.com/snipsnapdev/snipsnap/tree/master/snippets/javascript) and you have it in your package.json/yarn.lock.
 - Navigate through available snippets for your library and select the one you need.
 - Use tab in order to switch cursor between highlighted parts of the snippet.
@@ -79,9 +79,21 @@ No manual activation required as well, the extension triggers if your workspace 
 
 ## Settings
 
-The only available configuration option is possibility to exclude certain libraries from snippets request.
+### Silent mode
 
-Snipsnap works by gathering all deps throughout the project, even from lock files, so some of subdependencies like lodash could pollute your snippet environment and become a major frustrating factor.
+You can turn the successful snipet fetching notification off by specifying `snipsnap.silent` property's value to `true` in your VSCode's `settings.json`:
+
+```json
+// settings.json
+{
+  // other user settings
+  "snipsnap.silent": true
+}
+```
+
+### Ignore libraries
+
+Snipsnap works by gathering all deps throughout the project, even from lock files, so some of subdependencies like lodash could pollute your snippets environment and become a major frustrating factor.
 
 To ensure that no `%unwanted_library%` snippets are being fetched, you should create `.snipsnapignore.json` file at the root of your project and specify all libraries you want to be ignored in a single list, e.g.
 

--- a/helpers/common.js
+++ b/helpers/common.js
@@ -1,11 +1,5 @@
 // compose :: ((a -> b), (b -> c),  ..., (y -> z)) -> a -> z
-const compose = (...fns) => (...args) =>
-  fns.reduceRight((res, fn) => [fn.call(null, ...res)], args)[0];
-
-// functional approach to if-else clause
-// ifElse(cond: Boolean, if: Function, else: Function) -> Function
-const ifElse = (cond, ifCondTruthy, ifCondFalsy) =>
-  cond ? ifCondTruthy : ifCondFalsy;
+const compose = (...fns) => (...args) => fns.reduceRight((res, fn) => [fn.call(null, ...res)], args)[0];
 
 // curry :: ((a, b, ...) -> c) -> a -> b -> ... -> c
 const curry = (fn) => {
@@ -26,7 +20,6 @@ const uniqify = (arr) => Array.from(new Set(arr));
 
 module.exports = {
   compose,
-  ifElse,
   curry,
   uniqify,
 };

--- a/helpers/local.js
+++ b/helpers/local.js
@@ -70,7 +70,6 @@ const getFileContent = curry(($workspace, packageUri) =>
 // fetchSnippets(reqOptions: Object, reqPayload: JSON) -> Promise
 const fetchSnippets = (reqOptions, reqPayload) =>
   new Promise((resolve, reject) => {
-    console.log(reqPayload);
     const req = https
       .request('https://api.snipsnap.dev/snippets', reqOptions, (response) => {
         let body = '';

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
       }
     ],
     "configuration": {
-      "title": "SnipSnap",
+      "title": "Snipsnap",
       "properties": {
         "snipsnap.silent": {
           "type": "boolean",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,17 @@
         "title": "Fetch the snippets",
         "category": "Snipsnap"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "SnipSnap",
+      "properties": {
+        "snipsnap.silent": {
+          "type": "boolean",
+          "default": false,
+          "description": "Removes successfull fetching notification if enabled"
+        }
+      }
+    }
   },
   "scripts": {
     "test": "jest",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,7 +3,7 @@ module.exports = {
   tabWidth: 2,
   semi: true,
   singleQuote: true,
-  printWidth: 80,
+  printWidth: 120,
   useTabs: false,
   arrowParens: 'always',
 };


### PR DESCRIPTION
**Describe changes**

This PR introduces simple silent mode that will turn off the success fetching notifications once enabled via vscode's settings.

**Sideffects**

- Cleaned some minor things up along the way
- Removed unnecessary fn `ifElse`
- Commented out more `yarn` related code
- Adjusted prettier's `printWidth` setting` (80 -> 120)