### PR TITLE
Feat/yarn parser

### DIFF
--- a/commands/activate.js
+++ b/commands/activate.js
@@ -26,6 +26,7 @@ const snipsnapActivate = (workspace, packageUri) => {
         /*
          * get ready for an API call
          */
+        console.debug('req payload will be:', completeDepsList);
         const reqPayload = JSON.stringify({
           // TODO: think of a way of handling lang other than js
           language: 'javascript',

--- a/commands/activate.js
+++ b/commands/activate.js
@@ -4,7 +4,7 @@ const {
   getFileContent,
   injectSnippetFile,
   getSubDependencies,
-} = require('../helpers/local'); // fetchSnippets
+} = require('../helpers/local');
 
 // snipsnap_activate command handler
 const snipsnapActivate = (workspace, packageUri) => {
@@ -18,12 +18,7 @@ const snipsnapActivate = (workspace, packageUri) => {
         const { dependencies = {}, devDependencies = {} } = packageContent;
 
         // creating list of all project libraries
-        return Array.from(
-          new Set([
-            ...Object.keys(dependencies),
-            ...Object.keys(devDependencies),
-          ])
-        );
+        return Array.from(new Set([...Object.keys(dependencies), ...Object.keys(devDependencies)]));
       })
       // getting content of lock files
       .then(getSubDependencies(workspace))

--- a/helpers/local.js
+++ b/helpers/local.js
@@ -130,12 +130,16 @@ const getSubDependencies = curry(($workspace, mainDepsArray) =>
       $workspace
         .findFiles('package-lock.json', 1)
         .then((res) => (res.length ? getFileContent($workspace, res[0]) : { dependencies: [] }))
-        .then((pckgRes) =>
-          ignoreSpecifiedLibs(
+        .then((pckgRes) => {
+          // eslint-disable-next-line no-console
+          console.debug('yarn.lock packages:', yarnRes);
+          // eslint-disable-next-line no-console
+          console.debug('package-lock packages:', pckgRes);
+          return ignoreSpecifiedLibs(
             $workspace,
             compose(uniqify, transformSubModules)([...mainDepsArray, ...yarnRes, ...Object.keys(pckgRes.dependencies)])
-          )
-        )
+          );
+        })
     )
 );
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "snipsnap-vscode",
   "displayName": "Snipsnap - Code Snippets for Javascript libraries",
   "description": "Code snippets for React, Gatsby, Next.js, Redux and more",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "publisher": "snipsnapdev",
   "icon": "snipsnap-logo.jpg",
   "homepage": "https://marketplace.visualstudio.com/items?itemName=snipsnapdev.snipsnap-vscode",


### PR DESCRIPTION
**Describe changes**

This commit brings `yarn.lock` support via basic custom parser.

**Steps to test**

1. Pull the changes
2. Start debugging (or `F5`)
3. Open up a repo without any lock file
4. See that everything still works, the deps are taken directly form `package.json`, debug console spits out the payload correctly
5. Open up a repo with a `package-lock`, see that payload in debug console is extended with values from the file
6. Open up a repo with a `yarn.lock`, same
7. Finally, open up a repo with both `package-lock` and `yarn.lock`, see that nothing breaks and the snippets are still being fetched, taking the deps list from both files
8. Remove you own `snipsnap` extension
9. Run `vsce package`
10. Run `code --install-extension %filename%`
11. Open up random project folders, see that everything works after building in prod

**Related issues**
[#36](https://github.com/snipsnapdev/snipsnap/issues/36) from main repo