### PR TITLE
Fixed Snipsnap Marketplace url & name to find extension faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ To access base snippets for Javascript just type keyword `base` and you will see
 
 ## Installation
 
-Install through VS Code extensions. Search for `Snipsnap - Snippets Handler`
+Install through VS Code extensions. Search for `Snipsnap-vscode`
 
-[Visual Studio Code Market Place: Snipsnap - snippets handler](https://marketplace.visualstudio.com/items?itemName=snipsnapdev.snippsnap-vscode)
+[Visual Studio Code Market Place: Snipsnap - snippets handler](https://marketplace.visualstudio.com/items?itemName=snipsnapdev.snipsnap-vscode)
 
 Can also be installed in VS Code: Launch VS Code Quick Open (Ctrl+P), paste the following command, and press enter.
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "snipsnap.silent": {
           "type": "boolean",
           "default": false,
-          "description": "Removes successfull fetching notification if enabled"
+          "description": "Removes successful fetching notification if enabled"
         }
       }
     }


### PR DESCRIPTION
Fixed wrong url for extension in Marketplace and also changed the search string in order to find the extension faster in the Marketplace.

Old string was not pointing specifically to the extension alone.