### PR TITLE
Fixed yarn lock file parse issue

### DIFF
--- a/helpers/local.js
+++ b/helpers/local.js
@@ -10,7 +10,7 @@ const transformSubModules = (arr) => arr.map((key) => key.replace(/^@?(.+?)([/@:
 
 const parseYarnLock = (content) =>
   content
-    .replace(/(\n)/g, '#')
+    .replace(/(\r?\n)/g, '#')
     .split('##')
     .slice(2)
     .map((entry) => entry.replace(/["#]/g, '').replace(/^(.+?):.*/, '$1'));


### PR DESCRIPTION
Issue on Windows based systems where it wasn't parsing yarn.lock file correctly in some cases where it had line breaks that were \r